### PR TITLE
Group homepage projects into builder, design, and local business

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -18,43 +18,61 @@ module.exports = {
     angellist: `https://angel.co/u/chocksy`,
     // Content of the About Me section
     about: `Building tools that make developers and AI agents work better together. By day I lead development at <a href="https://hubstaff.com">Hubstaff</a>. By night I build AI developer tools like <a href="https://getcems.com">CEMS</a> (persistent memory for coding assistants) and <a href="https://ai-standups.com">AI Standups</a>. I've worked with Python, TypeScript, Ruby, Rails, React, Vue, and more — always picking the right tool for the job. Co-founder of <a href="https://github.com/EpicCoders">EpicCoders</a>.`,
-    // Optional: List your projects, they must have `name` and `description`. `link` is optional.
-    projects: [
+    projectGroups: [
       {
-        name: 'CEMS',
-        description:
-          'Persistent memory for AI coding assistants — Claude Code, Cursor, Codex, and Goose remember decisions, preferences, and context across sessions.',
-        link: 'https://getcems.com',
+        title: 'Builder tools',
+        items: [
+          {
+            name: 'Nodlock',
+            description:
+              'Approve Mac security prompts from your iPhone.',
+            link: 'https://nodlock.com',
+          },
+          {
+            name: 'CEMS',
+            description:
+              'Persistent memory for AI coding assistants — Claude Code, Cursor, Codex, and Goose remember decisions, preferences, and context across sessions.',
+            link: 'https://getcems.com',
+          },
+          {
+            name: 'Gooseherd',
+            description:
+              'Self-hosted AI coding agent orchestrator — herds Goose agents via Slack and opens PRs automatically.',
+            link: 'https://goose-herd.com',
+          },
+          {
+            name: 'Depsec',
+            description: 'Supply chain scanner, single binary.',
+            link: 'https://depsec.dev',
+          },
+          {
+            name: 'AI Standups',
+            description:
+              'Asynchronous daily stand-ups powered by AI — collect updates in Slack, surface blockers, and get auto-generated summaries.',
+            link: 'https://ai-standups.com',
+          },
+        ],
       },
       {
-        name: 'Gooseherd',
-        description:
-          'Self-hosted AI coding agent orchestrator — herds Goose agents via Slack and opens PRs automatically.',
-        link: 'https://goose-herd.com',
+        title: 'Design',
+        items: [
+          {
+            name: 'EpicPxls',
+            description:
+              'Marketplace for UI kits, fonts, and templates. Also includes AI Photo Studio at https://www.epicpxls.com/ai for birthday posters, coloring pages, and headshots, plus free tools including cake-topper STL.',
+            link: 'https://www.epicpxls.com',
+          },
+        ],
       },
       {
-        name: 'AI Standups',
-        description:
-          'Asynchronous daily stand-ups powered by AI — collect updates in Slack, surface blockers, and get auto-generated summaries.',
-        link: 'https://ai-standups.com',
-      },
-      {
-        name: 'Tapselo',
-        description:
-          'Point of sale for grocery stores — works offline, with fiscal receipts, integrated scale, and smart reports. Set up in 20 minutes on any computer.',
-        link: 'https://tapselo.com',
-      },
-      {
-        name: 'EpicPxls',
-        description:
-          'Design resources marketplace — free and premium icons, UI kits, and templates for developers and designers.',
-        link: 'https://www.epicpxls.com',
-      },
-      {
-        name: 'Hubstaff',
-        description:
-          'Lead developer — built the payroll system, scaled the codebase with Ruby on Rails, Vue.js, and PostgreSQL.',
-        link: 'https://hubstaff.com',
+        title: 'Local business',
+        items: [
+          {
+            name: 'Tapselo',
+            description: 'Point of sale for grocery stores in Romania.',
+            link: 'https://tapselo.com',
+          },
+        ],
       },
     ],
     // Optional: List your experience, they must have `name` and `description`. `link` is optional.

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -76,9 +76,14 @@ exports.createSchemaCustomization = ({ actions }) => {
       linkedin: String
       angellist: String
       about: String
-      projects: [SectionItem]
+      projectGroups: [ProjectGroup]
       experience: [SectionItem]
       skills: [SectionItem]
+    }
+
+    type ProjectGroup {
+      title: String!
+      items: [SectionItem]
     }
 
     type SectionItem {

--- a/src/components/section-projects/index.jsx
+++ b/src/components/section-projects/index.jsx
@@ -3,18 +3,29 @@ import React from 'react';
 import Section from '../section';
 import SummaryItem from '../summary-item';
 
-const SectionProjects = ({ projects }) => {
-  if (!projects.length) return null;
+const classes = {
+  group: 'mb-8 last:mb-0',
+  groupTitle:
+    'font-xs font-light tracking-widest text-sm text-gray-600 dark:text-gray-200 leading-normal uppercase mb-4',
+};
+
+const SectionProjects = ({ projectGroups }) => {
+  if (!projectGroups?.length) return null;
 
   return (
     <Section title="Projects">
-      {projects.map((project) => (
-        <SummaryItem
-          key={project.name}
-          name={project.name}
-          description={project.description}
-          link={project.link}
-        />
+      {projectGroups.map((group) => (
+        <div key={group.title} className={classes.group}>
+          <h3 className={classes.groupTitle}>{group.title}</h3>
+          {group.items.map((project) => (
+            <SummaryItem
+              key={project.name}
+              name={project.name}
+              description={project.description}
+              link={project.link}
+            />
+          ))}
+        </div>
       ))}
     </Section>
   );

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -14,7 +14,7 @@ import SEO from '../components/seo';
 
 const Index = ({ data }) => {
   const about = get(data, 'site.siteMetadata.about', false);
-  const projects = get(data, 'site.siteMetadata.projects', false);
+  const projectGroups = get(data, 'site.siteMetadata.projectGroups', false);
   const posts = data.allMarkdownRemark.edges;
   const experience = get(data, 'site.siteMetadata.experience', false);
   const skills = get(data, 'site.siteMetadata.skills', false);
@@ -25,7 +25,9 @@ const Index = ({ data }) => {
       <SEO />
       <Header metadata={data.site.siteMetadata} noBlog={noBlog} />
       {about && <SectionAbout about={about} />}
-      {projects && projects.length && <SectionProjects projects={projects} />}
+      {projectGroups && projectGroups.length && (
+        <SectionProjects projectGroups={projectGroups} />
+      )}
       <SectionAIStandups />
       {!noBlog && <SectionBlog posts={posts} />}
       {experience && experience.length && (
@@ -50,10 +52,13 @@ export const pageQuery = graphql`
         github
         linkedin
         angellist
-        projects {
-          name
-          description
-          link
+        projectGroups {
+          title
+          items {
+            name
+            description
+            link
+          }
         }
         experience {
           name


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the chocksy.com homepage Projects section to match the live portfolio structure: three labeled groups instead of one flat list.

## Changes

- Replaced flat `projects` siteMetadata with `projectGroups` (title + items)
- Updated `SectionProjects` to render group labels using the existing Section heading style
- Extended GraphQL schema in `gatsby-node.js` with `ProjectGroup` type
- Removed Hubstaff from Projects (still listed under Experience)

## Project groups

### Builder tools
1. **Nodlock** — https://nodlock.com — Approve Mac security prompts from iPhone
2. **CEMS** — https://getcems.com — Persistent memory for AI coding assistants
3. **Gooseherd** — https://goose-herd.com — Self-hosted AI coding agent orchestrator
4. **Depsec** — https://depsec.dev — Supply chain scanner, single binary
5. **AI Standups** — https://ai-standups.com — Asynchronous daily stand-ups powered by AI

### Design
- **EpicPxls** — https://www.epicpxls.com — Marketplace for UI kits, fonts, and templates; includes AI Photo Studio (https://www.epicpxls.com/ai) and free tools including cake-topper STL

### Local business
- **Tapselo** — https://tapselo.com — Point of sale for grocery stores in Romania

## Unchanged

- Tagline/description (AI Toolmaker)
- Dedicated `SectionAIStandups` block on the homepage
- Experience section (Hubstaff remains there)

## Verification

- `gatsby build` succeeds; GraphQL `projectGroups` query and siteMetadata schema build cleanly
- Homepage HTML includes all three group labels and project entries

## Deploy

Cloudflare Pages likely deploys this repo to https://chocksy.com after merge to the default branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81077180-0fa1-4111-8535-04661d277818?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81077180-0fa1-4111-8535-04661d277818&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

